### PR TITLE
add VFS implementation with Aliyun OSS

### DIFF
--- a/util/pkg/vfs/context.go
+++ b/util/pkg/vfs/context.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denverdino/aliyungo/oss"
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
 	"golang.org/x/net/context"
@@ -46,6 +47,8 @@ type VFSContext struct {
 	gcsClient *storage.Service
 	// swiftClient is the openstack swift client
 	swiftClient *gophercloud.ServiceClient
+	// ossClient is the Aliyun Open Source Storage client
+	ossClient *oss.Client
 }
 
 var Context = VFSContext{
@@ -118,6 +121,10 @@ func (c *VFSContext) BuildVfsPath(p string) (Path, error) {
 
 	if strings.HasPrefix(p, "swift://") {
 		return c.buildOpenstackSwiftPath(p)
+	}
+
+	if strings.HasPrefix(p, "oss://") {
+		return c.buildOSSPath(p)
 	}
 
 	return nil, fmt.Errorf("unknown / unhandled path type: %q", p)
@@ -342,4 +349,28 @@ func (c *VFSContext) buildOpenstackSwiftPath(p string) (*SwiftPath, error) {
 	}
 
 	return NewSwiftPath(c.swiftClient, bucket, u.Path)
+}
+
+func (c *VFSContext) buildOSSPath(p string) (*OSSPath, error) {
+	u, err := url.Parse(p)
+	if err != nil {
+		return nil, fmt.Errorf("invalid aliyun oss path: %q", p)
+	}
+
+	if u.Scheme != "oss" {
+		return nil, fmt.Errorf("invalid aliyun oss path: %q", p)
+	}
+
+	bucket := strings.TrimSuffix(u.Host, "/")
+	if bucket == "" {
+		return nil, fmt.Errorf("invalid aliyun oss path: %q", p)
+	}
+
+	ossClient, err := NewAliOSSClient()
+	if err != nil {
+		return nil, err
+	}
+	c.ossClient = ossClient
+
+	return NewOSSPath(c.ossClient, bucket, u.Path)
 }

--- a/util/pkg/vfs/osscontext.go
+++ b/util/pkg/vfs/osscontext.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vfs
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/denverdino/aliyungo/oss"
+)
+
+type aliyunOSSConfig struct {
+	region          oss.Region
+	internal        bool
+	accessKeyId     string
+	accessKeySecret string
+	secure          bool
+}
+
+func NewOSSPath(client *oss.Client, bucket string, key string) (*OSSPath, error) {
+	bucket = strings.TrimSuffix(bucket, "/")
+	key = strings.TrimPrefix(key, "/")
+
+	return &OSSPath{
+		client: client,
+		bucket: bucket,
+		key:    key,
+	}, nil
+}
+
+func NewAliOSSClient() (*oss.Client, error) {
+	c := &aliyunOSSConfig{}
+	err := c.loadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error building aliyun oss client: %v", err)
+	}
+
+	return oss.NewOSSClient(c.region, c.internal, c.accessKeyId, c.accessKeySecret, c.secure), nil
+}
+
+func (c *aliyunOSSConfig) loadConfig() error {
+	c.region = oss.Region(os.Getenv("ALIYUN_REGION"))
+	if c.region == "" {
+		// TODO: use default region
+		return fmt.Errorf("ALIYUN_REGION cannot be empty")
+	}
+	c.accessKeyId = os.Getenv("ALIYUN_ACCESS_KEY_ID")
+	if c.accessKeyId == "" {
+		return fmt.Errorf("ALIYUN_ACCESS_KEY_ID cannot be empty")
+	}
+	c.accessKeySecret = os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
+	if c.accessKeySecret == "" {
+		return fmt.Errorf("ALIYUN_ACCESS_KEY_SECRET cannot be empty")
+	}
+	c.internal = true
+	c.secure = true
+}

--- a/util/pkg/vfs/osscontext.go
+++ b/util/pkg/vfs/osscontext.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -69,4 +69,5 @@ func (c *aliyunOSSConfig) loadConfig() error {
 	}
 	c.internal = true
 	c.secure = true
+	return nil
 }

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -317,7 +317,7 @@ func (p *OSSPath) listPath(opt listOption) ([]Path, error) {
 				if comPrefLen != 0 {
 					lastComPref := resp.CommonPrefixes[comPrefLen-1]
 					if strings.Compare(lastComPref, opt.marker) == 1 {
-						opt.marker = resp.CommonPrefixes[comPrefLen-1]
+						opt.marker = lastComPref
 					}
 				}
 			} else {

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vfs
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/denverdino/aliyungo/oss"
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kops/util/pkg/hashing"
+)
+
+// OSSPath is a vfs path for Aliyun Open Storage Service
+type OSSPath struct {
+	client *oss.Client
+	bucket string
+	hash   string
+	key    string
+}
+
+var _ Path = &OSSPath{}
+var _ HasHash = &OSSPath{}
+
+// ossReadBackoff is the backoff strategy for Aliyun OSS read retries.
+var ossReadBackoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   1.5,
+	Jitter:   0.1,
+	Steps:    4,
+}
+
+// ossWriteBackoff is the backoff strategy for Aliyun OSS write retries
+var ossWriteBackoff = wait.Backoff{
+	Duration: time.Second,
+	Factor:   1.5,
+	Jitter:   0.1,
+	Steps:    5,
+}
+
+type listOption struct {
+	prefix string
+	delim  string
+	marker string
+	max    int
+}
+
+// WriteTo implements io.WriteTo
+func (p *OSSPath) WriteTo(out io.Writer) (int64, error) {
+	glog.V(4).Infof("Reading file %q", p)
+
+	b := p.client.Bucket(p.bucket)
+	headers := http.Header{}
+
+	response, err := b.GetResponseWithHeaders(p.key, headers)
+	if err != nil {
+		if isOSSNotFound(err) {
+			return 0, os.ErrNotExist
+		}
+		return 0, fmt.Errorf("error fetching %s: %v", p, err)
+	}
+	defer response.Body.Close()
+
+	n, err := io.Copy(out, response.Body)
+	if err != nil {
+		return n, fmt.Errorf("error reading %s: %v", p, err)
+	}
+	return n, nil
+}
+
+func (p *OSSPath) Join(relativePath ...string) Path {
+	args := []string{p.key}
+	args = append(args, relativePath...)
+	joined := path.Join(args...)
+	return &OSSPath{
+		client: p.client,
+		bucket: p.bucket,
+		key:    joined,
+	}
+}
+
+func (p *OSSPath) ReadFile() ([]byte, error) {
+	var b bytes.Buffer
+	done, err := RetryWithBackoff(ossReadBackoff, func() (bool, error) {
+		b.Reset()
+		_, err := p.WriteTo(&b)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Not recoverable
+				return true, err
+			}
+			return false, err
+		}
+		// Success!
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	} else if done {
+		return b.Bytes(), nil
+	} else {
+		// Shouldn't happen - we always return a non-nil error with false
+		return nil, wait.ErrWaitTimeout
+	}
+}
+
+func (p *OSSPath) WriteFile(data []byte, acl ACL) error {
+	b := p.client.Bucket(p.bucket)
+
+	done, err := RetryWithBackoff(ossWriteBackoff, func() (bool, error) {
+		glog.V(4).Infof("Writing file %q", p)
+
+		reader := bytes.NewReader(data)
+		dataLen := int64(len(data))
+		contType := "application/octet-stream"
+
+		var perm oss.ACL
+		if acl != nil {
+			perm, ok := acl.(*oss.ACL)
+			if !ok {
+				return true, fmt.Errorf("write to %s with ACL of unexpected type %T", p, acl)
+			}
+		} else {
+			// TODO: Maybe we should raise error when ACL is not provided
+			perm = oss.Private
+		}
+
+		err := b.PutReader(p.key, reader, dataLen, contType, perm, oss.Options{})
+		if err != nil {
+			return false, fmt.Errorf("error writing %s: %v", p, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	} else if done {
+		return nil
+	} else {
+		// Shouldn't happen - we always return a non-nil error with false
+		return wait.ErrWaitTimeout
+	}
+}
+
+// To prevent concurrent creates on the same file while maintaining atomicity of writes,
+// we take a process-wide lock during the operation.
+// Not a great approach, but fine for a single process (with low concurrency)
+// TODO: should we enable versioning?
+var createFileLockOSS sync.Mutex
+
+func (p *OSSPath) CreateFile(data []byte, acl ACL) error {
+	createFileLockOSS.Lock()
+	defer createFileLockOSS.Unlock()
+
+	// Check if exists
+	b := p.client.Bucket(p.bucket)
+	exist, err := b.Exists(p.key)
+	if err != nil {
+		return err
+	}
+	if exist {
+		return os.ErrExist
+	}
+
+	return p.WriteFile(data, acl)
+}
+
+func (p *OSSPath) Remove() error {
+	b := p.client.Bucket(p.bucket)
+
+	done, err := RetryWithBackoff(ossWriteBackoff, func() (bool, error) {
+		glog.V(8).Infof("removing file %s", p)
+
+		err := b.Del(p.key)
+		if err != nil {
+			return false, fmt.Errorf("error deleting %s: %v", p, err)
+		}
+		return true, nil
+	})
+	if err != nil {
+		return err
+	} else if done {
+		return nil
+	} else {
+		// Shouldn't happen - we always return a non-nil error with false
+		return wait.ErrWaitTimeout
+	}
+}
+
+func (p *OSSPath) Base() string {
+	return path.Base(p.key)
+}
+
+func (p *OSSPath) Path() string {
+	return "oss://" + p.bucket + "/" + p.key
+}
+
+func (p *OSSPath) ReadDir() ([]Path, error) {
+	prefix := p.key
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	// OSS can return at most 1000 paths(keys + common prefixes) at a time
+	opt := listOption{
+		prefix: prefix,
+		delim:  "/",
+		marker: "",
+		max:    1000,
+	}
+
+	return p.listPath(opt)
+}
+
+func (p *OSSPath) ReadTree() ([]Path, error) {
+	prefix := p.key
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	// OSS can return at most 1000 paths(keys + common prefixes) at a time
+	opt := listOption{
+		prefix: prefix,
+		// No delimiter for recursive search
+		delim:  "",
+		marker: "",
+		max:    1000,
+	}
+
+	return p.listPath(opt)
+}
+
+func (p *OSSPath) PreferredHash() (*hashing.Hash, error) {
+	return p.Hash(hashing.HashAlgorithmMD5)
+}
+
+func (p *OSSPath) Hash(a hashing.HashAlgorithm) (*hashing.Hash, error) {
+	if a != hashing.HashAlgorithmMD5 {
+		return nil, nil
+	}
+
+	md5 := p.hash
+	if md5 == "" {
+		return nil, nil
+	}
+
+	md5Bytes, err := hex.DecodeString(md5)
+	if err != nil {
+		return nil, fmt.Errorf("Etag was not a valid MD5 sum: %q", md5)
+	}
+
+	return &hashing.Hash{Algorithm: hashing.HashAlgorithmMD5, HashValue: md5Bytes}, nil
+}
+
+func (p *OSSPath) listPath(opt listOption) ([]Path, error) {
+	var ret []Path
+	b := p.client.Bucket(p.bucket)
+
+	done, err := RetryWithBackoff(ossReadBackoff, func() (bool, error) {
+
+		var paths []Path
+		for {
+			// OSS can return at most 1000 paths(keys + common prefixes) at a time
+			resp, err := b.List(opt.prefix, opt.delim, opt.marker, opt.max)
+			if err != nil {
+				if isOSSNotFound(err) {
+					return true, os.ErrNotExist
+				}
+				return false, fmt.Errorf("error listing %s: %v", p, err)
+			}
+
+			conLen := len(resp.Contents)
+			comPrefLen := len(resp.CommonPrefixes)
+			if conLen != 0 || comPrefLen != 0 {
+				for _, k := range resp.Contents {
+					child := &OSSPath{
+						client: p.client,
+						bucket: p.bucket,
+						key:    k.Key,
+					}
+					paths = append(paths, child)
+				}
+				if conLen != 0 {
+					opt.marker = resp.Contents[conLen-1].Key
+				}
+
+				// TODO: we might have to skip the original directory here?
+				for _, d := range resp.CommonPrefixes {
+					child := &OSSPath{
+						client: p.client,
+						bucket: p.bucket,
+						key:    d,
+					}
+					paths = append(paths, child)
+				}
+				if comPrefLen != 0 {
+					lastComPref := resp.CommonPrefixes[comPrefLen-1]
+					if strings.Compare(lastComPref, opt.marker) == 1 {
+						opt.marker = resp.CommonPrefixes[comPrefLen-1]
+					}
+				}
+			} else {
+				break
+			}
+		}
+		glog.V(8).Infof("Listed files in %v: %v", p, paths)
+		ret = paths
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	} else if done {
+		return ret, nil
+	} else {
+		// Shouldn't happen - we always return a non-nil error with false
+		return nil, wait.ErrWaitTimeout
+	}
+
+}
+
+func isOSSNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	ossErr, ok := err.(*oss.Error)
+	return ok && ossErr.StatusCode == 404
+}

--- a/util/pkg/vfs/ossfs.go
+++ b/util/pkg/vfs/ossfs.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -138,8 +138,9 @@ func (p *OSSPath) WriteFile(data []byte, acl ACL) error {
 		contType := "application/octet-stream"
 
 		var perm oss.ACL
+		var ok bool
 		if acl != nil {
-			perm, ok := acl.(*oss.ACL)
+			perm, ok = acl.(oss.ACL)
 			if !ok {
 				return true, fmt.Errorf("write to %s with ACL of unexpected type %T", p, acl)
 			}

--- a/util/pkg/vfs/ossfs_test.go
+++ b/util/pkg/vfs/ossfs_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2018 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/util/pkg/vfs/ossfs_test.go
+++ b/util/pkg/vfs/ossfs_test.go
@@ -1,0 +1,485 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vfs
+
+import (
+	"log"
+	"os"
+	"reflect"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/denverdino/aliyungo/oss"
+)
+
+var (
+	client     *oss.Client
+	testBucket = "kops-test-bucket"
+	testKey    = "kops-test-key"
+	TestRegion = oss.Region("oss-cn-hangzhou")
+
+	testData = []string{
+		"The quick brown fox jumps over the lazy dog",
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+		"Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
+		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
+	}
+	testDirKeys = []string{
+		"testdir/item_0",
+		"testdir/item_1",
+		"testdir/dir_0/item_2",
+		"testdir/dir_0/dir_1/item3",
+		"testdir/dir_0/dir_1/item4",
+	}
+	testLargeDirKeys = func() []string {
+		baseDir := "testlargedir/"
+		keys := make([]string, 2018)
+		for i := 0; i < 2018; i++ {
+			id := strconv.Itoa(i)
+			if i%4 == 0 {
+				keys[i] = baseDir + "dir_0/dir_1/item_" + id
+			} else if i%2 == 0 {
+				keys[i] = baseDir + "dir_0/item_" + id
+			} else {
+				keys[i] = baseDir + "item_" + id
+			}
+		}
+		return keys
+	}()
+)
+
+func init() {
+	AccessKeyId := os.Getenv("ALIYUN_ACCESS_KEY_ID")
+	AccessKeySecret := os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
+
+	if len(AccessKeyId) != 0 && len(AccessKeySecret) != 0 {
+		client = oss.NewOSSClient(TestRegion, false, AccessKeyId, AccessKeySecret, false)
+	} else {
+		// TODO: error handling
+		log.Fatalf("Unable to initialize client")
+	}
+
+	if !isBucketExists(testBucket) {
+		createBucket(testBucket)
+	}
+}
+
+func Test_OSSPath_Parse(t *testing.T) {
+	grid := []struct {
+		Input          string
+		ExpectError    bool
+		ExpectedBucket string
+		ExpectedPath   string
+	}{
+		{
+			Input:          "oss://bucket",
+			ExpectedBucket: "bucket",
+			ExpectedPath:   "",
+		},
+		{
+			Input:          "oss://bucket/path",
+			ExpectedBucket: "bucket",
+			ExpectedPath:   "path",
+		},
+		{
+			Input:          "oss://bucket2/path/subpath",
+			ExpectedBucket: "bucket2",
+			ExpectedPath:   "path/subpath",
+		},
+		{
+			Input:       "oss:///bucket/path/subpath",
+			ExpectError: true,
+		},
+	}
+	for _, g := range grid {
+		osspath, err := Context.buildOSSPath(g.Input)
+		t.Logf("%v, %v\n", osspath, err)
+		if !g.ExpectError {
+			if err != nil {
+				t.Fatalf("unexpected error parsing OSS path: %v", err)
+			}
+			if osspath.bucket != g.ExpectedBucket {
+				t.Fatalf("unexpected OSS path: %v", osspath)
+			}
+			if osspath.key != g.ExpectedPath {
+				t.Fatalf("unexpected oss path: %v", osspath)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("unexpected error parsing %q", g.Input)
+			}
+		}
+	}
+}
+
+func Test_ReadDir(t *testing.T) {
+	putMultiFiles(testBucket, testDirKeys)
+	defer delMultiFiles(testBucket, testDirKeys)
+
+	expectedKeys := []string{
+		"testdir/item_0",
+		"testdir/item_1",
+		"testdir/dir_0/",
+	}
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+	}
+
+	p.key = "testdir/"
+	paths, err := p.ReadDir()
+	if err != nil {
+		t.Fatalf("Unable to read directory: %v", err)
+	} else if len(paths) != len(expectedKeys) {
+		t.Fatalf("Number of items conflicts: expect %d, get %d", len(expectedKeys), len(paths))
+	} else {
+		var foundKeys []string
+		for _, path := range paths {
+			osspath := path.(*OSSPath)
+			foundKeys = append(foundKeys, osspath.key)
+		}
+		// TODO: any better compare method?
+		sort.Strings(expectedKeys)
+		sort.Strings(foundKeys)
+		if !reflect.DeepEqual(foundKeys, expectedKeys) {
+			t.Fatal("Read directory failed")
+		}
+	}
+}
+
+func Test_ReadTree(t *testing.T) {
+	putMultiFiles(testBucket, testDirKeys)
+	defer delMultiFiles(testBucket, testDirKeys)
+
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+	}
+
+	p.key = "testdir/"
+	paths, err := p.ReadTree()
+	if err != nil {
+		t.Fatalf("Unable to read directory: %v", err)
+	} else if len(paths) != len(testDirKeys) {
+		t.Fatalf("Number of items conflicts: expect %d, get %d", len(testDirKeys), len(paths))
+	} else {
+		var foundKeys []string
+		for _, path := range paths {
+			osspath := path.(*OSSPath)
+			foundKeys = append(foundKeys, osspath.key)
+		}
+		// TODO: any better compare method?
+		sort.Strings(testDirKeys)
+		sort.Strings(foundKeys)
+		if !reflect.DeepEqual(foundKeys, testDirKeys) {
+			t.Fatal("Read directory failed")
+		}
+	}
+}
+
+func Test_ReadLargeDir(t *testing.T) {
+	if !isObjectExists(testBucket, "testlargedir/item_1") {
+		putMultiFiles(testBucket, testLargeDirKeys)
+		defer delMultiFiles(testBucket, testLargeDirKeys)
+	}
+
+	expectedKeys := []string{
+		"testlargedir/dir_0/",
+	}
+	for i := 0; i < len(testLargeDirKeys); i++ {
+		if i%2 != 0 {
+			expectedKeys = append(expectedKeys, "testlargedir/item_"+strconv.Itoa(i))
+		}
+	}
+
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+		key:    "testlargedir/",
+	}
+
+	paths, err := p.ReadDir()
+	if err != nil {
+		t.Fatalf("Unable to read directory: %v", err)
+	} else if len(paths) != len(expectedKeys) {
+		t.Fatalf("Number of items conflicts: expect %d, get %d", len(expectedKeys), len(paths))
+	} else {
+		var foundKeys []string
+		for _, path := range paths {
+			osspath := path.(*OSSPath)
+			foundKeys = append(foundKeys, osspath.key)
+		}
+		// TODO: any better compare method?
+		sort.Strings(expectedKeys)
+		sort.Strings(foundKeys)
+		if !reflect.DeepEqual(foundKeys, expectedKeys) {
+			t.Fatal("Read directory failed")
+		}
+	}
+}
+
+func Test_ReadLargeTree(t *testing.T) {
+	if !isObjectExists(testBucket, "testlargedir/item_1") {
+		putMultiFiles(testBucket, testLargeDirKeys)
+		defer delMultiFiles(testBucket, testLargeDirKeys)
+	}
+
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+		key:    "testlargedir/",
+	}
+
+	paths, err := p.ReadTree()
+	if err != nil {
+		t.Fatalf("Unable to read directory: %v", err)
+	} else if len(paths) != len(testLargeDirKeys) {
+		t.Fatalf("Number of items conflicts: expect %d, get %d", len(testLargeDirKeys), len(paths))
+	} else {
+		var foundKeys []string
+		for _, path := range paths {
+			osspath := path.(*OSSPath)
+			foundKeys = append(foundKeys, osspath.key)
+		}
+		// TODO: any better compare method?
+		sort.Strings(testLargeDirKeys)
+		sort.Strings(foundKeys)
+		if !reflect.DeepEqual(foundKeys, testLargeDirKeys) {
+			t.Fatal("Read directory failed")
+		}
+	}
+}
+func Test_CreateFile(t *testing.T) {
+	grid := []struct {
+		Key           string
+		ExpectError   bool
+		ExpectContent string
+	}{
+		{
+			Key:           "test-createfile-key",
+			ExpectError:   false,
+			ExpectContent: testData[2],
+		},
+		{
+			Key:           "test-createfile-key",
+			ExpectError:   true,
+			ExpectContent: testData[2],
+		},
+	}
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+	}
+	// TODO: ACL mode
+	acl := oss.Private
+
+	for _, g := range grid {
+		p.key = g.Key
+		err := p.CreateFile([]byte(g.ExpectContent), acl)
+		if g.ExpectError {
+			if err == nil || err != os.ErrExist {
+				t.Fatalf("Unexpected error creating file: %v", err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Unable to create file: %v", err)
+			} else {
+				// verification
+				content := string(getFileByRawInterface(p.bucket, p.key))
+				if content != g.ExpectContent {
+					t.Fatalf("File contents conflict: expect '%s', get '%s'", g.ExpectContent, content)
+				}
+			}
+		}
+	}
+}
+
+func Test_Remove(t *testing.T) {
+	grid := []struct {
+		Key         string
+		ExpectError bool
+	}{
+		{
+			Key:         "test-createfile-key",
+			ExpectError: false,
+		},
+		// TODO: aliyun SDK bugs: DEL non-existed file does not raise error
+		// {
+		// 	Key:         "test-createfile-key",
+		// 	ExpectError: true,
+		// },
+	}
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+	}
+
+	for _, g := range grid {
+		p.key = g.Key
+		err := p.Remove()
+		if g.ExpectError {
+			// TODO: error check?
+			if err == nil {
+				t.Fatalf("Unexpected error removing file: %v", err)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("Unable to remove file: %v", err)
+			}
+		}
+	}
+}
+
+func Test_WriteFile(t *testing.T) {
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+		key:    testKey,
+	}
+
+	// TODO: any test on ACL mode?
+	acl := oss.Private
+	err := p.WriteFile([]byte(testData[0]), acl)
+	if err != nil {
+		t.Fatalf("Unable to write file: %v", err)
+	}
+
+	// verfication
+	content := string(getFileByRawInterface(p.bucket, p.key))
+	if content != testData[0] {
+		t.Fatalf("File contents conflict: expect '%s', get '%s'", testData[0], content)
+	}
+}
+
+func Test_ReadFile(t *testing.T) {
+	p := &OSSPath{
+		client: client,
+		bucket: testBucket,
+		key:    testKey,
+	}
+
+	// pre write
+	putFileByRawInterface(p.bucket, p.key, []byte(testData[1]))
+
+	data, err := p.ReadFile()
+	if err != nil {
+		t.Fatalf("Unable to read file: %v", err)
+	} else if string(data) != testData[1] {
+		t.Fatalf("File contents conflict: expect '%s', get '%s'", testData[1], string(data))
+	}
+}
+
+func getFileByRawInterface(bucket string, key string) []byte {
+	data, err := client.Bucket(bucket).Get(key)
+	if err != nil {
+		log.Fatalf("error in reading file: %v", err)
+	}
+	return data
+}
+
+func putFileByRawInterface(bucket string, key string, data []byte) {
+	contType := "application/octet-stream"
+	perm := oss.Private
+	err := client.Bucket(bucket).Put(key, data, contType, perm, oss.Options{})
+	if err != nil {
+		log.Fatalf("error in writing file: %v", err)
+	}
+}
+
+func putMultiFiles(bucket string, files []string) {
+	// TODO: ACL mode
+	acl := oss.Private
+	var wg sync.WaitGroup
+	wg.Add(len(files))
+	for _, k := range files {
+		go func(key string) {
+			path := &OSSPath{
+				client: client,
+				bucket: bucket,
+				key:    key,
+			}
+			err := path.CreateFile([]byte{}, acl)
+			wg.Done()
+			if err != nil {
+				log.Fatalf("error in creating files: %v", err)
+			}
+		}(k)
+	}
+	wg.Wait()
+}
+
+func delMultiFiles(bucket string, files []string) {
+	// teardown
+	var wg sync.WaitGroup
+	wg.Add(len(files))
+	for _, k := range files {
+		go func(key string) {
+			path := &OSSPath{
+				client: client,
+				bucket: bucket,
+				key:    key,
+			}
+			err := path.Remove()
+			wg.Done()
+			if err != nil {
+				log.Fatalf("error in teardown: %v", err)
+			}
+		}(k)
+	}
+	wg.Wait()
+}
+
+func createBucket(bucket string) {
+	// Create bucket on aliyun
+	b := client.Bucket(bucket)
+	err := b.PutBucket(oss.Private)
+	if err != nil {
+		// TODO: error handing
+		log.Fatalf("Unable to create bucket: %v", err)
+	}
+}
+
+func deleteBucket(bucket string) {
+	// Delete bucket on aliyun
+	b := client.Bucket(bucket)
+	err := b.DelBucket()
+	if err != nil {
+		// TODO: error handling
+		log.Fatalf("Unable to delete bucket: %v", err)
+	}
+}
+
+func isBucketExists(bucket string) bool {
+	b := client.Bucket(bucket)
+	_, err := b.Info()
+	if err == nil {
+		return true
+	}
+	ossErr, ok := err.(*oss.Error)
+	// TODO: maybe it's subjective to say only 404 represents NOT_EXISTS
+	return !(ok && ossErr.StatusCode == 404)
+}
+
+func isObjectExists(bucket string, path string) bool {
+	exists, err := client.Bucket(bucket).Exists(path)
+	if err != nil {
+		log.Fatalf("error in checking object existence: %v", err)
+	}
+	return exists
+}

--- a/util/pkg/vfs/vfs.go
+++ b/util/pkg/vfs/vfs.go
@@ -101,7 +101,7 @@ func IsClusterReadable(p Path) bool {
 	}
 
 	switch p.(type) {
-	case *S3Path, *GSPath, *SwiftPath:
+	case *S3Path, *GSPath, *SwiftPath, *OSSPath:
 		return true
 
 	case *KubernetesPath:


### PR DESCRIPTION
**Do not merge, just for review and criticism**.

Add a new VFS implementation which enables kops to store state with Aliyun OSS when deploying k8s cluster on AliCloud.

``` go
// get Aliyun OSS client
func NewOSSClient(region Region, internal bool, accessKeyId string, accessKeySecret string, secure bool) *Client
```
For now, users have to set three environment variables, `ALIYUN_ACCESS_KEY_ID`, `ALIYUN_ACCESS_KEY_SECRET` and `ALIYUN_REGION`, to generate a OSS client, while `internal` and `secure` are always `true`.

Unit tests would be added by next Monday.

Signed-off-by: Xiao An <hac@zju.edu.cn>