### PR TITLE
initial cloud interface & add feature flags for alicloud

### DIFF
--- a/pkg/apis/kops/channel.go
+++ b/pkg/apis/kops/channel.go
@@ -250,6 +250,7 @@ const CloudProviderGCE CloudProviderID = "gce"
 const CloudProviderDO CloudProviderID = "digitalocean"
 const CloudProviderVSphere CloudProviderID = "vsphere"
 const CloudProviderOpenstack CloudProviderID = "openstack"
+const CloudProviderALI CloudProviderID = "alicloud"
 
 // FindImage returns the image for the cloudprovider, or nil if none found
 func (c *Channel) FindImage(provider CloudProviderID, kubernetesVersion semver.Version) *ChannelImageSpec {

--- a/pkg/apis/kops/validation/legacy.go
+++ b/pkg/apis/kops/validation/legacy.go
@@ -105,7 +105,11 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 	case kops.CloudProviderOpenstack:
 		requiresNetworkCIDR = false
 		requiresSubnetCIDR = false
-
+		//TODO: In the next development, ali cloud can provide Subnets support.
+	case kops.CloudProviderALI:
+		requiresSubnets = false
+		requiresSubnetCIDR = false
+		requiresNetworkCIDR = false
 	default:
 		return field.Invalid(fieldSpec.Child("CloudProvider"), c.Spec.CloudProvider, "CloudProvider not recognized")
 	}
@@ -300,6 +304,8 @@ func ValidateCluster(c *kops.Cluster, strict bool) *field.Error {
 			k8sCloudProvider = ""
 		case kops.CloudProviderOpenstack:
 			k8sCloudProvider = "openstack"
+		case kops.CloudProviderALI:
+			k8sCloudProvider = "alicloud"
 		default:
 			return field.Invalid(fieldSpec.Child("CloudProvider"), c.Spec.CloudProvider, "unknown cloudprovider")
 		}

--- a/upup/pkg/fi/cloud.go
+++ b/upup/pkg/fi/cloud.go
@@ -204,9 +204,44 @@ var zonesToCloud = map[string]kops.CloudProviderID{
 	"fra1": kops.CloudProviderDO,
 
 	"blr1": kops.CloudProviderDO,
+
+	"cn-qingdao-b": kops.CloudProviderALI,
+	"cn-qingdao-c": kops.CloudProviderALI,
+
+	"cn-beijing-a": kops.CloudProviderALI,
+	"cn-beijing-b": kops.CloudProviderALI,
+	"cn-beijing-c": kops.CloudProviderALI,
+	"cn-beijing-d": kops.CloudProviderALI,
+	"cn-beijing-e": kops.CloudProviderALI,
+
+	"cn-zhangjiakou-a": kops.CloudProviderALI,
+
+	"cn-huhehaote-a": kops.CloudProviderALI,
+
+	"cn-hangzhou-b": kops.CloudProviderALI,
+	"cn-hangzhou-c": kops.CloudProviderALI,
+	"cn-hangzhou-d": kops.CloudProviderALI,
+	"cn-hangzhou-e": kops.CloudProviderALI,
+	"cn-hangzhou-f": kops.CloudProviderALI,
+	"cn-hangzhou-g": kops.CloudProviderALI,
+
+	"cn-shanghai-a": kops.CloudProviderALI,
+	"cn-shanghai-b": kops.CloudProviderALI,
+	"cn-shanghai-c": kops.CloudProviderALI,
+	"cn-shanghai-d": kops.CloudProviderALI,
+
+	"cn-shenzhen-a": kops.CloudProviderALI,
+	"cn-shenzhen-b": kops.CloudProviderALI,
+	"cn-shenzhen-c": kops.CloudProviderALI,
+
+	"cn-hongkong-a": kops.CloudProviderALI,
+	"cn-hongkong-b": kops.CloudProviderALI,
+	"cn-hongkong-c": kops.CloudProviderALI,
 }
 
 // GuessCloudForZone tries to infer the cloudprovider from the zone name
+// Ali has the same zoneNames as AWS in the regions outside China, so if use AliCloud to install k8s in the regions outside China,
+// the users need to provide parameter "--cloud". But the regions inside China can be easily identified.
 func GuessCloudForZone(zone string) (kops.CloudProviderID, bool) {
 	c, found := zonesToCloud[zone]
 	return c, found

--- a/upup/pkg/fi/cloudup/aliup/ali_apitarget.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_apitarget.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aliup
+
+import (
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+type ALIAPITarget struct {
+	Cloud ALICloud
+}
+
+var _ fi.Target = &ALIAPITarget{}
+
+func NewALIAPITarget(cloud ALICloud) *ALIAPITarget {
+	return &ALIAPITarget{
+		Cloud: cloud,
+	}
+}
+
+func (t *ALIAPITarget) Finish(taskMap map[string]fi.Task) error {
+	return nil
+}
+
+func (t *ALIAPITarget) ProcessDeletions() bool {
+	return true
+}

--- a/upup/pkg/fi/cloudup/aliup/ali_cloud.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_cloud.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aliup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	ecs "github.com/denverdino/aliyungo/ecs"
+	"k8s.io/api/core/v1"
+	"k8s.io/kops/dnsprovider/pkg/dnsprovider"
+	"k8s.io/kops/pkg/apis/kops"
+	"k8s.io/kops/pkg/cloudinstances"
+	"k8s.io/kops/upup/pkg/fi"
+)
+
+const TagClusterName = "KubernetesCluster"
+
+type ALICloud interface {
+	fi.Cloud
+
+	EcsClient() *ecs.Client
+	Region() string
+}
+
+type aliCloudImplementation struct {
+	ecsClient *ecs.Client
+	region    string
+	tags      map[string]string
+}
+
+var _ fi.Cloud = &aliCloudImplementation{}
+
+// NewALICloud returns a Cloud, expecting the env vars ALIYUN_ACCESS_KEY_ID && ALIYUN_ACCESS_KET_SECRET
+// NewALICloud will return an err if env vars are not defined
+func NewALICloud(region string, tags map[string]string) (ALICloud, error) {
+
+	c := &aliCloudImplementation{region: region}
+
+	accessKeyId := os.Getenv("ALIYUN_ACCESS_KEY_ID")
+	if accessKeyId == "" {
+		return nil, errors.New("ALIYUN_ACCESS_KEY_ID is required")
+	}
+	accessKeySecret := os.Getenv("ALIYUN_ACCESS_KET_SECRET")
+	if accessKeySecret == "" {
+		return nil, errors.New("ALIYUN_ACCESS_KET_SECRET is required")
+	}
+
+	escclient := ecs.NewClient(accessKeyId, accessKeySecret)
+	c.ecsClient = escclient
+	c.tags = tags
+
+	return c, nil
+}
+
+func (c *aliCloudImplementation) EcsClient() *ecs.Client {
+	return c.ecsClient
+}
+
+func (c *aliCloudImplementation) Region() string {
+	return c.region
+}
+
+func (c *aliCloudImplementation) ProviderID() kops.CloudProviderID {
+	return kops.CloudProviderALI
+}
+
+func (c *aliCloudImplementation) DNS() (dnsprovider.Interface, error) {
+	return nil, fmt.Errorf("DNS not implemented on aliCloud")
+}
+
+func (c *aliCloudImplementation) DeleteGroup(g *cloudinstances.CloudInstanceGroup) error {
+	return fmt.Errorf("DeleteGroup not implemented on aliCloud")
+}
+
+func (c *aliCloudImplementation) DeleteInstance(i *cloudinstances.CloudInstanceGroupMember) error {
+	return fmt.Errorf("DeleteInstance not implemented on aliCloud")
+}
+
+func (c *aliCloudImplementation) FindVPCInfo(id string) (*fi.VPCInfo, error) {
+	return nil, fmt.Errorf("FindVPCInfo not implemented on aliCloud")
+}
+
+func (c *aliCloudImplementation) GetCloudGroups(cluster *kops.Cluster, instancegroups []*kops.InstanceGroup, warnUnmatched bool, nodes []v1.Node) (map[string]*cloudinstances.CloudInstanceGroup, error) {
+	return nil, fmt.Errorf("GetCloudGroups not implemented on aliCloud")
+}

--- a/upup/pkg/fi/cloudup/aliup/ali_utils.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_utils.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aliup
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+// FindRegion determines the region from the zones specified in the cluster
+func FindRegion(cluster *kops.Cluster) (string, error) {
+
+	region := ""
+	for _, subnet := range cluster.Spec.Subnets {
+		zoneSplit := strings.Split(subnet.Zone, "-")
+		zoneRegion := ""
+		if len(zoneSplit) != 3 {
+			return "", fmt.Errorf("invalid ALI zone: %q in subnet %q", subnet.Zone, subnet.Name)
+		}
+
+		if len(zoneSplit[2]) == 1 {
+			zoneRegion = zoneSplit[0] + "-" + zoneSplit[1]
+		} else if len(zoneSplit[2]) == 2 {
+			zoneRegion = subnet.Zone[:len(subnet.Zone)-1]
+		} else {
+			return "", fmt.Errorf("invalid ALI zone: %q in subnet %q", subnet.Zone, subnet.Name)
+		}
+
+		if region != "" && zoneRegion != region {
+			return "", fmt.Errorf("Clusters cannot span multiple regions (found zone %q, but region is %q)", subnet.Zone, region)
+		}
+		region = zoneRegion
+	}
+
+	return region, nil
+}

--- a/upup/pkg/fi/cloudup/aliup/ali_utils_test.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_utils_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aliup
+
+import (
+	"testing"
+
+	"k8s.io/kops/pkg/apis/kops"
+)
+
+func TestFindRegion(t *testing.T) {
+	testZones := []string{"cn-qingdao-b", "cn-hangzhou-b", "ap-southeast-1a", "ap-southeast-2a"}
+	expectedRegionds := []string{"cn-qingdao", "cn-hangzhou", "ap-southeast-1", "ap-southeast-2"}
+
+	for i, zone := range testZones {
+		c := &kops.Cluster{}
+		c.Spec.Subnets = append(c.Spec.Subnets, kops.ClusterSubnetSpec{Name: "subnet-" + zone, Zone: zone})
+
+		region, err := FindRegion(c)
+		if err != nil {
+			t.Fatalf("unexpected error finding region for %q: %v", zone, err)
+		}
+
+		expected := expectedRegionds[i]
+		if region != expected {
+			t.Fatalf("unexpected region for zone: %q vs %q", expected, region)
+		}
+	}
+
+}

--- a/upup/pkg/fi/cloudup/utils.go
+++ b/upup/pkg/fi/cloudup/utils.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kops/dnsprovider/pkg/dnsprovider/providers/aws/route53"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/upup/pkg/fi"
+	"k8s.io/kops/upup/pkg/fi/cloudup/aliup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/awsup"
 	"k8s.io/kops/upup/pkg/fi/cloudup/baremetal"
 	"k8s.io/kops/upup/pkg/fi/cloudup/do"
@@ -141,6 +142,21 @@ func BuildCloud(cluster *kops.Cluster) (fi.Cloud, error) {
 			cloud = osc
 		}
 
+	case kops.CloudProviderALI:
+		{
+			region, err := aliup.FindRegion(cluster)
+			if err != nil {
+				return nil, err
+			}
+
+			cloudTags := map[string]string{aliup.TagClusterName: cluster.ObjectMeta.Name}
+			aliCloud, err := aliup.NewALICloud(region, cloudTags)
+			if err != nil {
+				return nil, err
+			}
+
+			cloud = aliCloud
+		}
 	default:
 		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)
 	}


### PR DESCRIPTION
If kops users don‘t provide parameter "--cloud" while creating k8s, the cloudProvider can be recognized by zoneName, but Ali cloud has the same zoneNames as AWS in the regions outside China, so the Ali users outside China have to use the parameter "--cloud" .