### PR TITLE
fix bugs that blocks create_cluster

### DIFF
--- a/channels/stable
+++ b/channels/stable
@@ -28,6 +28,8 @@ spec:
       kubernetesVersion: ">=1.10.0"
     - providerID: gce
       name: "cos-cloud/cos-stable-60-9592-90-0"
+    - providerID: alicloud
+      name: "ubuntu_16_0402_64_20G_alibase_20171227.vhd"
   cluster:
     kubernetesVersion: v1.5.8
     networking:

--- a/pkg/model/alimodel/api_loadbalancer.go
+++ b/pkg/model/alimodel/api_loadbalancer.go
@@ -51,9 +51,9 @@ func (b *APILoadBalancerModelBuilder) Build(c *fi.ModelBuilderContext) error {
 
 	switch lbSpec.Type {
 	case kops.LoadBalancerTypeInternal:
-		// OK
-	case kops.LoadBalancerTypePublic:
 		return fmt.Errorf("internal LoadBalancers are not yet supported by kops on ALI")
+	case kops.LoadBalancerTypePublic:
+		// pass
 	default:
 		return fmt.Errorf("unhandled LoadBalancer type %q", lbSpec.Type)
 	}

--- a/pkg/model/components/apiserver.go
+++ b/pkg/model/components/apiserver.go
@@ -117,6 +117,8 @@ func (b *KubeAPIServerOptionsBuilder) BuildOptions(o interface{}) error {
 		// for baremetal, we don't specify a cloudprovider to apiserver
 	case kops.CloudProviderOpenstack:
 		c.CloudProvider = "openstack"
+	case kops.CloudProviderALI:
+		c.CloudProvider = "alicloud"
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)
 	}

--- a/pkg/model/components/kubecontrollermanager.go
+++ b/pkg/model/components/kubecontrollermanager.go
@@ -115,6 +115,8 @@ func (b *KubeControllerManagerOptionsBuilder) BuildOptions(o interface{}) error 
 
 	case kops.CloudProviderOpenstack:
 		kcm.CloudProvider = "openstack"
+	case kops.CloudProviderALI:
+		kcm.CloudProvider = "alicloud"
 
 	default:
 		return fmt.Errorf("unknown cloudprovider %q", clusterSpec.CloudProvider)

--- a/pkg/model/components/kubelet.go
+++ b/pkg/model/components/kubelet.go
@@ -179,6 +179,10 @@ func (b *KubeletOptionsBuilder) BuildOptions(o interface{}) error {
 		clusterSpec.Kubelet.CloudProvider = "openstack"
 	}
 
+	if cloudProvider == kops.CloudProviderALI {
+		clusterSpec.Kubelet.CloudProvider = "alicloud"
+	}
+
 	if clusterSpec.ExternalCloudControllerManager != nil {
 		clusterSpec.Kubelet.CloudProvider = "external"
 	}

--- a/upup/pkg/fi/cloudup/aliup/ali_cloud.go
+++ b/upup/pkg/fi/cloudup/aliup/ali_cloud.go
@@ -59,7 +59,7 @@ type aliCloudImplementation struct {
 
 var _ fi.Cloud = &aliCloudImplementation{}
 
-// NewALICloud returns a Cloud, expecting the env vars ALIYUN_ACCESS_KEY_ID && ALIYUN_ACCESS_KET_SECRET
+// NewALICloud returns a Cloud, expecting the env vars ALIYUN_ACCESS_KEY_ID && ALIYUN_ACCESS_KEY_SECRET
 // NewALICloud will return an err if env vars are not defined
 func NewALICloud(region string, tags map[string]string) (ALICloud, error) {
 
@@ -69,9 +69,9 @@ func NewALICloud(region string, tags map[string]string) (ALICloud, error) {
 	if accessKeyId == "" {
 		return nil, errors.New("ALIYUN_ACCESS_KEY_ID is required")
 	}
-	accessKeySecret := os.Getenv("ALIYUN_ACCESS_KET_SECRET")
+	accessKeySecret := os.Getenv("ALIYUN_ACCESS_KEY_SECRET")
 	if accessKeySecret == "" {
-		return nil, errors.New("ALIYUN_ACCESS_KET_SECRET is required")
+		return nil, errors.New("ALIYUN_ACCESS_KEY_SECRET is required")
 	}
 
 	escclient := ecs.NewClient(accessKeyId, accessKeySecret)

--- a/upup/pkg/fi/cloudup/apply_cluster.go
+++ b/upup/pkg/fi/cloudup/apply_cluster.go
@@ -64,6 +64,7 @@ import (
 	"k8s.io/kops/upup/pkg/fi/cloudup/vspheretasks"
 	"k8s.io/kops/upup/pkg/fi/fitasks"
 	"k8s.io/kops/util/pkg/vfs"
+	"k8s.io/kops/pkg/model/alimodel"
 )
 
 const (
@@ -415,6 +416,11 @@ func (c *ApplyClusterCmd) Run() error {
 			l.AddTypes(map[string]interface{}{
 				"Disk": &alitasks.Disk{},
 				"Vpc": &alitasks.VPC{},
+				"SecurityGroup": &alitasks.SecurityGroup{},
+				"SecurityGroupRule": &alitasks.SecurityGroupRule{},
+				"LoadBalancer": &alitasks.LoadBalancer{},
+				"LoadBalancerListener": &alitasks.LoadBalancerListener{},
+				"LoadBalancerWhiteList": &alitasks.LoadBalancerWhiteList{},
 			})
 		}
 
@@ -553,6 +559,16 @@ func (c *ApplyClusterCmd) Run() error {
 					)
 				}
 
+			case kops.CloudProviderALI:
+				aliModelContext := &alimodel.ALIModelContext{
+					KopsModelContext: modelContext,
+				}
+				l.Builders = append(l.Builders,
+					&alimodel.APILoadBalancerModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.FirewallModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+					&alimodel.ExternalAccessModelBuilder{ALIModelContext: aliModelContext, Lifecycle: &clusterLifecycle},
+				)
+
 			case kops.CloudProviderVSphere:
 				// No special settings (yet!)
 
@@ -618,6 +634,13 @@ func (c *ApplyClusterCmd) Run() error {
 				BootstrapScript: bootstrapScriptBuilder,
 				Lifecycle:       &clusterLifecycle,
 			})
+		}
+	case kops.CloudProviderALI:
+		{
+			// TODO
+			//aliModelContext := &alimodel.ALIModelContext{
+			//	KopsModelContext: modelContext,
+			//}
 		}
 	case kops.CloudProviderVSphere:
 		{

--- a/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
+++ b/upup/pkg/fi/cloudup/populate_instancegroup_spec.go
@@ -34,13 +34,16 @@ const (
 	defaultNodeMachineTypeGCE     = "n1-standard-2"
 	defaultNodeMachineTypeVSphere = "vsphere_node"
 	defaultNodeMachineTypeDO      = "2gb"
+	defaultNodeMachineTypeALI     = "ecs.n4.xlarge"
 
 	defaultBastionMachineTypeGCE     = "f1-micro"
 	defaultBastionMachineTypeVSphere = "vsphere_bastion"
+	defaultBastionMachineTypeALI     = "ecs.n4.small"
 
 	defaultMasterMachineTypeGCE     = "n1-standard-1"
 	defaultMasterMachineTypeVSphere = "vsphere_master"
 	defaultMasterMachineTypeDO      = "2gb"
+	defaultMasterMachineTypeALI     = "ecs.n4.xlarge"
 
 	defaultVSphereNodeImage = "kops_ubuntu_16_04.ova"
 	defaultDONodeImage      = "coreos-stable"
@@ -200,6 +203,17 @@ func defaultMachineType(cluster *kops.Cluster, ig *kops.InstanceGroup) (string, 
 
 		case kops.InstanceGroupRoleBastion:
 			return defaultBastionMachineTypeVSphere, nil
+		}
+	case kops.CloudProviderALI:
+		switch ig.Spec.Role {
+		case kops.InstanceGroupRoleMaster:
+			return defaultMasterMachineTypeALI, nil
+
+		case kops.InstanceGroupRoleNode:
+			return defaultNodeMachineTypeALI, nil
+
+		case kops.InstanceGroupRoleBastion:
+			return defaultBastionMachineTypeALI, nil
 		}
 	}
 

--- a/upup/pkg/fi/cloudup/tagbuilder.go
+++ b/upup/pkg/fi/cloudup/tagbuilder.go
@@ -80,6 +80,11 @@ func buildCloudupTags(cluster *api.Cluster) (sets.String, error) {
 
 	case api.CloudProviderOpenstack:
 
+	case api.CloudProviderALI:
+		{
+			tags.Insert("_ali")
+		}
+
 	default:
 		return nil, fmt.Errorf("unknown CloudProvider %q", cluster.Spec.CloudProvider)
 	}
@@ -158,6 +163,9 @@ func buildNodeupTags(role api.InstanceGroupRole, cluster *api.Cluster, clusterTa
 	}
 	if clusterTags.Has("_do") {
 		tags.Insert("_do")
+	}
+	if clusterTags.Has("_ali") {
+		tags.Insert("_ali")
 	}
 
 	return tags, nil

--- a/util/pkg/vfs/osscontext.go
+++ b/util/pkg/vfs/osscontext.go
@@ -67,7 +67,12 @@ func (c *aliyunOSSConfig) loadConfig() error {
 	if c.accessKeySecret == "" {
 		return fmt.Errorf("ALIYUN_ACCESS_KEY_SECRET cannot be empty")
 	}
-	c.internal = true
+	ossInternal := os.Getenv("ALIYUN_OSS_INTERNAL")
+	if ossInternal != "" {
+		c.internal = true
+	} else {
+		c.internal = false
+	}
 	c.secure = true
 	return nil
 }


### PR DESCRIPTION
Add ALIYUN_OSS_INTERNAL to use oss internal domain, use public by default.
Fix typo ALIYUN_ACCESS_KET_SECRET to ALIYUN_ACCESS_KEY_SECRET.

Test code below:
export KOPS_STATE_STORE=oss://kops-aliyun-test/
export ALIYUN_REGION=oss-cn-hangzhou
export ALIYUN_ACCESS_KEY_ID=ID
export ALIYUN_ACCESS_KEY_SECRET=KEY
export KOPS_FEATURE_FLAGS=AlphaAllowALI
./kops create cluster hello.k8s.local --cloud alicloud --zones cn-hangzhou-a -v 10
