### PR TITLE
support create VPC 

### DIFF
--- a/pkg/model/alimodel/context.go
+++ b/pkg/model/alimodel/context.go
@@ -115,7 +115,7 @@ func (c *ALIModelContext) GetAutoscalingGroupName(ig *kops.InstanceGroup) string
 		// We need to keep this back-compatible, so we introduce the masters name,
 		// though the IG name suffices for uniqueness, and with sensible naming masters
 		// should be redundant...
-		return "masters." + c.ClusterName()
+		return ig.ObjectMeta.Name[len(ig.ObjectMeta.Name)-3:] + ".masters." + c.ClusterName()
 	case kops.InstanceGroupRoleNode:
 		return "node." + c.ClusterName()
 	case kops.InstanceGroupRoleBastion:

--- a/upup/pkg/fi/cloudup/alitasks/vpc.go
+++ b/upup/pkg/fi/cloudup/alitasks/vpc.go
@@ -84,7 +84,7 @@ func (e *VPC) Find(c *fi.Context) (*VPC, error) {
 	}
 
 	for _, vpc := range vpcs {
-		if vpc.CidrBlock == fi.StringValue(e.CIDR) {
+		if vpc.CidrBlock == fi.StringValue(e.CIDR) && vpc.VpcName == fi.StringValue(e.Name) {
 			actual := &VPC{
 				ID:        fi.String(vpc.VpcId),
 				CIDR:      fi.String(vpc.CidrBlock),
@@ -144,6 +144,7 @@ func (_ *VPC) RenderALI(t *aliup.ALIAPITarget, a, e, changes *VPC) error {
 		request := &ecs.CreateVpcArgs{
 			RegionId:  common.Region(t.Cloud.Region()),
 			CidrBlock: fi.StringValue(e.CIDR),
+			VpcName:   fi.StringValue(e.Name),
 		}
 
 		response, err := t.Cloud.EcsClient().CreateVpc(request)

--- a/upup/pkg/fi/cloudup/defaults.go
+++ b/upup/pkg/fi/cloudup/defaults.go
@@ -50,7 +50,7 @@ func PerformAssignments(c *kops.Cluster) error {
 	}
 
 	// Currently only AWS uses NetworkCIDRs
-	setNetworkCIDR := cloud.ProviderID() == kops.CloudProviderAWS
+	setNetworkCIDR := (cloud.ProviderID() == kops.CloudProviderAWS) || (cloud.ProviderID() == kops.CloudProviderALI)
 	if setNetworkCIDR && c.Spec.NetworkCIDR == "" {
 		if c.SharedVPC() {
 			vpcInfo, err := cloud.FindVPCInfo(c.Spec.NetworkID)
@@ -65,8 +65,12 @@ func PerformAssignments(c *kops.Cluster) error {
 				return fmt.Errorf("Unable to infer NetworkCIDR from VPC ID, please specify --network-cidr")
 			}
 		} else {
-			// TODO: Choose non-overlapping networking CIDRs for VPCs, using vpcInfo
-			c.Spec.NetworkCIDR = "172.20.0.0/16"
+			if cloud.ProviderID() == kops.CloudProviderAWS {
+				// TODO: Choose non-overlapping networking CIDRs for VPCs, using vpcInfo
+				c.Spec.NetworkCIDR = "172.20.0.0/16"
+			} else if cloud.ProviderID() == kops.CloudProviderALI {
+				c.Spec.NetworkCIDR = "192.168.0.0/16"
+			}
 		}
 
 		// Amazon VPC CNI uses the same network
@@ -85,7 +89,7 @@ func PerformAssignments(c *kops.Cluster) error {
 	}
 
 	// We only assign subnet CIDRs on AWS
-	if cloud.ProviderID() == kops.CloudProviderAWS {
+	if cloud.ProviderID() == kops.CloudProviderAWS || cloud.ProviderID() == kops.CloudProviderALI {
 		// TODO: Use vpcInfo
 		err = assignCIDRsToSubnets(c)
 		if err != nil {


### PR DESCRIPTION
If the user does not provide vpc parameters, kops will create a vpc with cidr parameters(default 192.168.0.0/16), and divided into seven sub-network segment to create VSwitchs. 